### PR TITLE
Get fonts from app folder and show preview with it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ RUN source activate && conda activate karaoke_env && \
     langchain \
     langchain_google_genai \
     gradio \
-    matplotlib \
     colorama
 
 RUN source activate && conda activate karaoke_env && \
@@ -74,7 +73,6 @@ RUN source activate && conda activate karaoke_env && \
     langchain \
     langchain_google_genai \
     gradio \
-    matplotlib \
     colorama && \
   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126 && \
   pip cache purge && \
@@ -97,7 +95,7 @@ FROM install AS publish
 
 WORKDIR /app
 RUN echo '' > ./requirements.txt
-COPY app.py LICENSE README.md .
+COPY app.py LICENSE README.md ./
 COPY interface ./interface
 COPY modules ./modules
 

--- a/README.md
+++ b/README.md
@@ -417,7 +417,8 @@ docker compose up --no-build
 ---
 
 ### Step 3: Karaoke Video Generation
-1. **Subtitle Style**: Choose font, color, highlight, outline, and shadow settings.
+1. **Subtitle Style**: Choose font, color, highlight, outline, and shadow settings.  
+   App searches Font files in app folder `fonts/`. Copy needed fonts in folder and restart app.
 1. **Background Effects**: Optional looping `.mp4` files can be selected for a dynamic background.
 1. **Advanced Video Settings**: Set resolution (`720p`, `1080p`), FPS, bitrate, etc., based on your quality needs.
 1. **Generate Karaoke**: Click the button to produce your final video.

--- a/app.py
+++ b/app.py
@@ -5,13 +5,13 @@ from interface.main_app import main_app
 
 def run():
     # Initialize the project directories
-    project_root, cache_dir, output_dir = initialize_directories()
+    project_root, cache_dir, fonts_dir, output_dir = initialize_directories()
 
     # Configure logging based on the verbose flag
     configure_logging(verbose=False)
 
     # Launch the main application
-    app = main_app(cache_dir, output_dir, project_root)
+    app = main_app(cache_dir, fonts_dir, output_dir, project_root)
     app.launch()
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - 7860:7860
     volumes:
       - ./cache:/app/cache:rw
+      - ./fonts:/app/fonts:ro
       - ./effects:/app/effects:ro
       - ./logs:/app/logs:rw
       - ./output:/app/output:rw

--- a/fonts/.gitignore
+++ b/fonts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/interface/callbacks.py
+++ b/interface/callbacks.py
@@ -8,7 +8,8 @@ import json
 from .helpers import (
     display_dataframe_from_lyrics,
     load_json_file,
-    save_json_file
+    save_json_file,
+    get_font_format,
 )
 from .handlers import handle_audio_processing
 from modules import (
@@ -281,6 +282,7 @@ def generate_font_preview_callback(
     outline_size: int,
     shadow_color: str,
     shadow_size: int,
+    available_fonts: dict,
 ):
     """
     Generates the subtitle file and returns a formatted HTML preview of subtitles.
@@ -296,8 +298,16 @@ def generate_font_preview_callback(
         f'{preview_text[split_index:]}</span>'
     )
 
+    font_format = get_font_format(available_fonts[font])
+
     # Generate preview HTML
     preview_html = f"""
+    <style >
+        @font-face {{
+            font-family: {font};
+            src: url('gradio_api/file={available_fonts[font]}') format('{font_format}');
+        }}
+    </style>
     <div style="
         font-family: {font};
         font-size: 24px;  /* Fixed size for compact preview */

--- a/interface/helpers.py
+++ b/interface/helpers.py
@@ -3,6 +3,7 @@ from typing import List, Union
 from pathlib import Path
 import logging
 import json
+import os
 
 # Third-Party Imports
 import pandas as pd
@@ -176,3 +177,26 @@ def check_generate_karaoke_availability(working_dir: str) -> dict:
         return gr.update(interactive=True)
     else:
         return gr.update(interactive=False)
+
+
+def get_font_format(filepath: str) -> str:
+    """
+    Retrieve a font format for CSS-font-family.
+
+    Parameters:
+        filepath (str): Path to the file of font.
+
+    Returns:
+        str: Font format.
+    """
+    extension = os.path.splitext(filepath)[1].lower()
+
+    match extension:
+        case '.ttf':  # TrueType Font
+            return 'truetype'
+        case '.woff' | '.woff2':  # Web Open Font Format
+            return extension[1:]
+        case ".otf":  # OpenType Font
+            return 'opentype'
+        case _:
+            return ''

--- a/interface/main_app.py
+++ b/interface/main_app.py
@@ -27,12 +27,13 @@ from modules import (
 import pandas as pd
 
 # Main App Interface
-def main_app(cache_dir, output_dir, project_root):
+def main_app(cache_dir, fonts_dir, output_dir, project_root):
+    gr.set_static_paths(fonts_dir)
     with gr.Blocks(theme='shivi/calm_seafoam') as app:
         effects_dir = project_root / "effects"
 
         # Get available fonts and colors for subtitles
-        available_fonts = get_font_list()
+        available_fonts = get_font_list(fonts_dir)
         available_colors = get_available_colors()
         available_effects = ["None"] + get_effect_video_list(effects_dir)
         available_langs = ["Auto Detect"] + sorted(get_available_languages().keys())
@@ -217,8 +218,8 @@ def main_app(cache_dir, output_dir, project_root):
         with gr.Row():
             # --- Subtitles basic options ---
             font_input = gr.Dropdown(
-                choices=available_fonts,
-                value="Maiandra GD",
+                choices=list(available_fonts.keys()),
+                value="",
                 label="Font"
             )
             primary_color_input = gr.Dropdown(
@@ -372,7 +373,7 @@ def main_app(cache_dir, output_dir, project_root):
         #             SUBTITLE STYLE PREVIEW (live updates on color/font changes)
         ##############################################################################
         def update_subtitle_preview(*args):
-            return generate_font_preview_callback(*args)
+            return generate_font_preview_callback(*args, available_fonts=available_fonts)
 
         font_preview_inputs = [
             font_input,
@@ -572,4 +573,4 @@ def main_app(cache_dir, output_dir, project_root):
             outputs=[karaoke_video_output]  # or karaoke_status_output, or both
         )
 
-    return app
+        return app

--- a/modules/config.py
+++ b/modules/config.py
@@ -48,10 +48,12 @@ def initialize_directories():
 
     project_root = _get_project_root()
     cache_dir = project_root / "cache"
+    fonts_dir = project_root / "fonts"
     output_dir = project_root / "output"
 
     # Ensure that the cache and output directories exist
     cache_dir.mkdir(parents=True, exist_ok=True)
+    fonts_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    return project_root, cache_dir, output_dir
+    return project_root, cache_dir, fonts_dir, output_dir

--- a/modules/subtitle_processing/config.py
+++ b/modules/subtitle_processing/config.py
@@ -1,12 +1,29 @@
 # Third-party imports
-import matplotlib.font_manager as fm
+import os
 
+def get_font_list(font_directory):
+    """
+    Retrieve a dictionary containing font filenames (without extension) and their full paths.
 
-def get_font_list():
-    """Retrieve a list of unique font names."""
-    fonts = [f.name for f in fm.fontManager.ttflist]
-    unique_fonts = set(fonts)
-    return sorted(unique_fonts)
+    Parameters:
+        font_directory (str): Path to the directory containing font files.
+
+    Returns:
+        dict: Dictionary in the format (font_name, font_path).
+    """
+    font_dict = {}
+    if not os.path.isdir(font_directory):
+        return font_dict
+
+    for filename in os.listdir(font_directory):
+        extension = os.path.splitext(filename)[1].lower()
+        match extension:
+            case '.ttf' | '.woff' | '.woff2' | '.otf':
+                font_path = os.path.join(font_directory, filename)
+                font_name = os.path.splitext(filename)[0]
+                font_dict[font_name] = font_path
+
+    return font_dict
 
 def get_available_colors():
     """Generate a dictionary of color names and their ASS-compatible codes."""

--- a/modules/video_processing/utilities.py
+++ b/modules/video_processing/utilities.py
@@ -2,7 +2,6 @@ import subprocess
 import time
 import os
 from colorama import Fore, Style
-import matplotlib.font_manager as fm
 
 def extract_audio_duration(audio_path):
     """

--- a/setup.bat
+++ b/setup.bat
@@ -77,7 +77,6 @@ call pip install deep_translator
 call pip install langchain
 call pip install langchain_google_genai
 call pip install --upgrade gradio
-call python -m pip install -U matplotlib
 
 echo Setup complete! Run "conda activate karaoke_env" to start using your environment.
 pause


### PR DESCRIPTION
The previous version had a problem where Linux system fonts were not visible from Windows, so the karaoke text preview in the browser was not displayed correctly.
Now I load some fonts into the application's "fonts/" folder and everything works fine.

It was more advantageous to form a drop-down list from file names, since mathplotlib gave the same names for different fonts of the same font-family.

But I haven't set up the font files to be specified in the ass-subtitle file yet.